### PR TITLE
use _.isEqual instead of _.matches

### DIFF
--- a/src/sync.js
+++ b/src/sync.js
@@ -1,6 +1,6 @@
 var constants = require('redux-persist/constants');
 var keyPrefix = constants.keyPrefix;
-var matches = require('lodash/utility/matches');
+var isEqual = require('lodash/lang/isEqual');
 
 function sync(persistor, config){
   if (config === undefined) config = {};
@@ -11,7 +11,7 @@ function sync(persistor, config){
 
   function handleStorageEvent(e){
     var key = Object.keys(e)[0];
-    if(key && key.indexOf(keyPrefix) === 0 && (!chrome.storage.local._lastData || !matches(e[key].newValue)(chrome.storage.local._lastData))){
+    if(key && key.indexOf(keyPrefix) === 0 && (!chrome.storage.local._lastData || !isEqual(e[key].newValue, chrome.storage.local._lastData))){
       var keyspace = key.substr(keyPrefix.length);
       if(whitelist && whitelist.indexOf(keyspace) === -1){ return }
       if(blacklist && blacklist.indexOf(keyspace) !== -1){ return }


### PR DESCRIPTION
It seems like _.matches([])(anything) always return true, so it will not
sync when program clear redux store.
